### PR TITLE
memory leak in three functions

### DIFF
--- a/src/DeltaMonitor.cpp
+++ b/src/DeltaMonitor.cpp
@@ -187,9 +187,8 @@ DeltaMonitor::Output(ostream &out)
 	std::string s;
 
 	get_sequence(s);
-	ofstream *ofile = new ofstream(output_file_.c_str());
-	*ofile << s;
-	ofile->close();
+	ofstream ofile(output_file_.c_str());
+	ofile << s;
 }
 
 const std::string &

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -1064,27 +1064,27 @@ void
 Probabilities::dump_default_probabilities(const string &fname)
 {
 	assert(!fname.empty());
-	ofstream *out = new ofstream(fname.c_str());
-	std::map<ProbName, ProbElem*>::iterator i;
+	ofstream out(fname.c_str());
+
+	std::map<ProbName, ProbElem*>::iterator i; 
 	for (i = probabilities_.begin(); i != probabilities_.end(); ++i) {
-		(*i).second->dump_default(*out);
-		*out << std::endl << std::endl;
+		(*i).second->dump_default(out);
+		out << std::endl << std::endl;
 	}
-	out->close();
 }
 
 void
 Probabilities::dump_actual_probabilities(const string &fname, unsigned long seed)
 {
 	assert(!fname.empty());
-	ofstream *out = new ofstream(fname.c_str());
-	*out << "# Seed: " << seed << std::endl << std::endl;
+	ofstream out(fname.c_str());
+	out << "# Seed: " << seed << std::endl << std::endl;
+
 	std::map<ProbName, ProbElem*>::iterator i;
 	for (i = probabilities_.begin(); i != probabilities_.end(); ++i) {
-		(*i).second->dump_val(*out);
-		*out << std::endl << std::endl;
+		(*i).second->dump_val(out);
+		out << std::endl << std::endl;
 	}
-	out->close();
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In all three functions, a std::ofstream object is created by calling operator new.
The pointer returned by new is stored in a local variable and never explicitly deleted.

The fix creates the std::ofstream on the stack.
The file attached to the std::ofstream object is closed by the destructor.