### PR TITLE
runtime: allow combined CSMITH_MINIMAL and USE_MATH_MACROS*

### DIFF
--- a/runtime/csmith_minimal.h
+++ b/runtime/csmith_minimal.h
@@ -52,7 +52,15 @@ extern int printf (const char *, ...);
 // FIXME
 #define assert(x)
 
+#if defined (USE_MATH_MACROS_NOTMP)
+#include "safe_math_macros_notmp.h"
+#elif defined (USE_MATH_MACROS)
+#include "safe_math_macros.h"
+#else
+#define FUNC_NAME(x) (safe_##x)
 #include "safe_math.h"
+#undef FUNC_NAME
+#endif
 
 static inline void platform_main_begin(void)
 {


### PR DESCRIPTION
On the one hand, CSMITH_MINIMAL allows using csmith_minimal.h instead
of csmith.h, thus reducing the size of includes in Csmith-generated
files (in particular by avoiding the inclusion of too many standard
header files.)

On the other hand, USE_MATH_MACROS allows replacing functions defined
in safe_math.h with macros (which reduces the size of includes in
Csmith-generated files, in particular if they were generated using
--no-safe-math).

Previously, CSMITH_MINIMAL used to disable USE_MATH_MACROS. Now,
thanks to this commit, both preprocessing/compilation symbols can be
used together and their effects combined.

For more details, see the discussion on the csmith-dev mailing list,
starting from
http://www.flux.utah.edu/listarchives/csmith-dev/msg00494.html