### PR TITLE
replace C standard headers by their C++ counterparts

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -31,8 +31,8 @@
 
 #include "CGOptions.h"
 #include <iostream>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <map>
 #include "Fact.h"
 #include "DefaultOutputMgr.h"

--- a/src/CVQualifiers.cpp
+++ b/src/CVQualifiers.cpp
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include "CVQualifiers.h"
 #include "Type.h"

--- a/src/Fact.cpp
+++ b/src/Fact.cpp
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <assert.h>
+#include <cassert>
 #include "Fact.h"
 #include "Variable.h"
 #include "Lhs.h"

--- a/src/FactPointTo.cpp
+++ b/src/FactPointTo.cpp
@@ -49,7 +49,7 @@
 #include "Lhs.h"
 #include "random.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace std;
 

--- a/src/FactUnion.cpp
+++ b/src/FactUnion.cpp
@@ -41,7 +41,7 @@
 #include "FunctionInvocationUser.h"
 #include "ExpressionAssign.h"
 #include "ExpressionComma.h"
-#include <assert.h>
+#include <cassert>
 
 const int  FactUnion::TOP = -2;
 const int  FactUnion::BOTTOM = -1;

--- a/src/Lhs.cpp
+++ b/src/Lhs.cpp
@@ -29,7 +29,6 @@
 
 #include "Lhs.h"
 #include <cassert>
-#include <assert.h>
 #include <iostream>
 #include "CGContext.h"
 #include "CGOptions.h"

--- a/src/ProbabilityTable.h
+++ b/src/ProbabilityTable.h
@@ -33,7 +33,7 @@
 #include <vector>
 #include <algorithm>
 #include <functional>
-#include <assert.h>
+#include <cassert>
 #include "Probabilities.h"
 #include "VectorFilter.h"
 #include "CGOptions.h"

--- a/src/Reducer.cpp
+++ b/src/Reducer.cpp
@@ -32,10 +32,10 @@
 #endif
 
 #include "Reducer.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include "StringUtils.h"
 #include "Function.h"
 #include "FunctionInvocationUser.h"

--- a/src/StatementBreak.cpp
+++ b/src/StatementBreak.cpp
@@ -33,7 +33,7 @@
 
 #include "StatementBreak.h"
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include "CGOptions.h"
 #include "CGContext.h"
 #include "Block.h"

--- a/src/StatementContinue.cpp
+++ b/src/StatementContinue.cpp
@@ -33,7 +33,7 @@
 
 #include "StatementContinue.h"
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include "CGOptions.h"
 #include "CGContext.h"
 #include "Block.h"

--- a/src/StatementGoto.cpp
+++ b/src/StatementGoto.cpp
@@ -33,7 +33,7 @@
 
 #include "StatementGoto.h"
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include "CGOptions.h"
 #include "CGContext.h"
 #include "Block.h"

--- a/src/StatementIf.cpp
+++ b/src/StatementIf.cpp
@@ -31,7 +31,7 @@
 #pragma warning(disable : 4786)   /* Disable annoying warning messages */
 #endif
 
-#include <assert.h>
+#include <cassert>
 #include "StatementIf.h"
 #include <iostream>
 #include "CGOptions.h"

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -38,8 +38,8 @@
 
 #include "Type.h"
 #include <sstream>
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 #include "Common.h"
 #include "CGOptions.h"
 #include "random.h"

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -90,10 +90,10 @@ unsigned long platform_gen_seed()
 #ifndef WIN32
 #include <sys/stat.h>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #else
 #include <direct.h>
-#include <errno.h>
+#include <cerrno>
 #endif
 
 bool create_dir(const char *dir)

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -32,7 +32,6 @@
 
 #include <cassert>
 #include <cstdlib>
-#include <stdlib.h>
 
 #include "random.h"
 #include "RandomNumber.h"


### PR DESCRIPTION
e.g., "assert.h  -->   cassert"

checked under OS X, Linux and Windows