### PR TITLE
Fix PowerPC read_time()

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -45,20 +45,13 @@
 #include "platform.h"
 
 #if (TARGET_CPU_powerpc == 1 || TARGET_CPU_powerpc64 == 1)
-/*For PPC, got from:
-http://lists.ozlabs.org/pipermail/linuxppc-dev/1999-October/003889.html
-*/
-static unsigned long long read_time(void) {
-	unsigned long long retval;
-	unsigned long junk;
-	__asm__ __volatile__ ("\n\
-1:	mftbu %1\n\
-	mftb %L0\n\
-	mftbu %0\n\
-	cmpw %0,%1\n\
-	bne 1b"
-	: "=r" (retval), "=r" (junk));
-	return retval;
+static inline unsigned long read_time(void)
+{
+	unsigned long a;
+
+	asm volatile("mftb %0" : "=r" (a));
+
+	return a;
 }
 #else
 #ifdef WIN32


### PR DESCRIPTION
The inline assembly used for the PowerPC version of read_time() is
broken:

```
$ ./src/csmith |grep Seed
 * Seed:      276270
$ ./src/csmith |grep Seed
 * Seed:      276270
$ ./src/csmith |grep Seed
 * Seed:      276270
```

Since platform_gen_seed() only returns a long we can simplify things
and just use mftb. With the patch applied we see correct behaviour:

```
$ ./src/csmith |grep Seed
 * Seed:      1186590549319330
$ ./src/csmith |grep Seed
 * Seed:      1186590989534520
$ ./src/csmith |grep Seed
 * Seed:      1186591288978819
```