### PR TITLE
Add PowerPC little endian support and remove TARGET_CPU_* defines

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -47,13 +47,7 @@ libcsmith_la_SOURCES = \
 GIT_HASH := $(shell "$(top_srcdir)/git-hash.sh" "$(top_srcdir)" || echo error)
 GIT_FLAG = -DGIT_VERSION=\"$(GIT_HASH)\"
 
-## ENE: The idea of stuffing the target CPU name (a string) into a CPP symbol
-## is kind of awful.  What we should do instead is use the name to modify the
-## include path, e.g., -I"$(target_cpu)".  But that refactoring is for a later
-## day...
-
 libcsmith_a_CPPFLAGS = \
-	-DTARGET_CPU_$(target_cpu)=1 \
 	$(GIT_FLAG)
 libcsmith_la_CPPFLAGS = \
 	$(libcsmith_a_CPPFLAGS)

--- a/runtime/Makefile.in
+++ b/runtime/Makefile.in
@@ -361,7 +361,6 @@ libcsmith_la_SOURCES = \
 GIT_HASH := $(shell "$(top_srcdir)/git-hash.sh" "$(top_srcdir)" || echo error)
 GIT_FLAG = -DGIT_VERSION=\"$(GIT_HASH)\"
 libcsmith_a_CPPFLAGS = \
-	-DTARGET_CPU_$(target_cpu)=1 \
 	$(GIT_FLAG)
 
 libcsmith_la_CPPFLAGS = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,13 +200,7 @@ EXTRA_DIST = \
 GIT_HASH := $(shell "$(top_srcdir)/git-hash.sh" "$(top_srcdir)" || echo error)
 GIT_FLAG = -DGIT_VERSION=\"$(GIT_HASH)\"
 
-## ENE: The idea of stuffing the target CPU name (a string) into a CPP symbol
-## is kind of awful.  What we should do instead is use the name to modify the
-## include path, e.g., -I"$(target_cpu)".  But that refactoring is for a later
-## day...
-
 csmith_CPPFLAGS = \
-	-DTARGET_CPU_$(target_cpu)=1 \
 	$(GIT_FLAG) \
 	$(BOOST_CPPFLAGS)
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -541,7 +541,6 @@ EXTRA_DIST = \
 GIT_HASH := $(shell "$(top_srcdir)/git-hash.sh" "$(top_srcdir)" || echo error)
 GIT_FLAG = -DGIT_VERSION=\"$(GIT_HASH)\"
 csmith_CPPFLAGS = \
-	-DTARGET_CPU_$(target_cpu)=1 \
 	$(GIT_FLAG) \
 	$(BOOST_CPPFLAGS)
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -44,7 +44,7 @@
 
 #include "platform.h"
 
-#if (TARGET_CPU_powerpc == 1 || TARGET_CPU_powerpc64 == 1)
+#if defined(__powerpc__) || defined(__powerpc64__)
 static inline unsigned long read_time(void)
 {
 	unsigned long a;


### PR DESCRIPTION
The PowerPC version of read_time() is not being selected on
little endian because we are only catching the big endian cases:

    #if (TARGET_CPU_powerpc == 1 || TARGET_CPU_powerpc64 == 1)

This is the only place we use TARGET_CPU_*, and it is simpler (and
more common) to use standard c pre-processor defines:

    #if defined(__powerpc__) || defined(__powerpc64__)

This works on gcc, llvm/clang and IBM xlc. With this change we can
remove TARGET_CPU_* completely.