### PR TITLE
custom_stdint: define int8_t as "signed char"

### DIFF
--- a/runtime/custom_stdint_x86.h
+++ b/runtime/custom_stdint_x86.h
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define int8_t char
+#define int8_t signed char
 #define uint8_t unsigned char
 
 #define int16_t short


### PR DESCRIPTION
I am no C standard expert, but after a lot of debugging and reading I
think that int8_t should be defined as signed char instead of char.

AFAICT the signedness of char is implementation defined so when
comparing toolchains with this header file you can get false-positives.

PS: I see that stdint_ia32.h defines int8_t as "signed char" so applying
this patch will make custom_stdint_x86.h consistent with stdint_ia32.h.