### PR TITLE
separate if statements for Incr and Decr operators

### DIFF
--- a/src/StatementFor.cpp
+++ b/src/StatementFor.cpp
@@ -106,11 +106,14 @@ make_random_loop_control(int &init, int &limit, int &incr,
 			incr_op = pure_rnd_flipcoin(50) ? ePreIncr : ePostIncr;
 		}
 		if (((incr_op == ePreIncr) && !CGOptions::pre_incr_operator())
-			|| ((incr_op == ePostIncr) && !CGOptions::post_incr_operator())
-			|| ((incr_op == ePreDecr) && !CGOptions::pre_decr_operator())
+			|| ((incr_op == ePostIncr) && !CGOptions::post_incr_operator())) {
+
+			incr_op = eAddAssign;
+		}
+		if (((incr_op == ePreDecr) && !CGOptions::pre_decr_operator())
 			|| ((incr_op == ePostDecr) && !CGOptions::post_decr_operator())) {
 
-			incr_op = (limit >= init) ? eAddAssign : eSubAssign;
+			incr_op = eSubAssign;
 		}
 		incr = 1;
 	}


### PR DESCRIPTION
The condition on **StatementFor.cpp:103** eliminates any chance of an overflow/underflow when **CGOptions::fast_execution()** is disabled.

However, in **StatementFor.cpp:113**, the fact that **incr_op** is assigned depending only on the condition **limit >= init**  re-introduces the chance of an overflow/underflow when **limit == init**.

I 'm not sure if this behaviour is intentional. If it is you can ignore this pull request.