### PR TITLE
Fix invalid size assertion

### DIFF
--- a/src/SafeOpFlags.cpp
+++ b/src/SafeOpFlags.cpp
@@ -260,6 +260,9 @@ SafeOpFlags::OutputSize(std::ostream &out) const
 	case sInt64:
 		out << "int64_t";
 		break;
+	case sFloat:
+		out << "float";
+		break;
 	default:
 		assert(!"invalid size!");
 		break;


### PR DESCRIPTION
When running with `--no-safe-math --float`, Csmith would often fail with:
```
csmith: SafeOpFlags.cpp:264: void SafeOpFlags::OutputSize(std::ostream&) const: Assertion !"invalid size!" failed.
```

This patch adds the forgotten case in that function. Fixes issue #42.