### PR TITLE
adding experiment of how clang-format and clang are effected temporal…

### DIFF
--- a/contrib/anylize_stress_fmt.py
+++ b/contrib/anylize_stress_fmt.py
@@ -1,0 +1,7 @@
+import pandas
+import sys 
+# Load the data into a DataFrame
+#data = pandas.read_csv('times.csv')
+data = pandas.read_csv(sys.stdin)
+print data.describe()
+  

--- a/contrib/stress_fmt.py
+++ b/contrib/stress_fmt.py
@@ -1,0 +1,22 @@
+# Usage: python stress_fmt.py | python anylize_stress_fmt.py
+# Requires clang-format in your path
+import os
+import time
+
+print "clang_fmt_llvm, clang_fmt_google, clang_raw, clang_llvm, clang_google"
+for x in xrange(100):
+	
+	os.system("../src/csmith > test.c")
+	t1 = time.time()
+	os.system("clang-format -style=LLVM test.c > test_llvm.c")
+	t2 = time.time()
+	os.system("clang-format -style=Google test.c > test_google.c")
+	t3 = time.time()	
+	os.system("clang -I../runtime -O -w test.c -o /dev/null")
+	t4 = time.time()
+	os.system("clang -I../runtime -O -w test_llvm.c -o /dev/null")
+	t5 = time.time()
+	os.system("clang -I../runtime -O -w test_google.c -o /dev/null")
+	t6 = time.time()
+	
+	print '{0},{1},{2},{3},{4}'.format(t2-t1, t3-t2, t4-t3, t5-t4, t6-t5)


### PR DESCRIPTION
I spiked a few scripts to study temporal regressions from csmith programs. Both how long clang-format takes on various styles, and how various styles effect the compile time of clang. From 100 samples it looks like Google's format is slightly faster on average than Raw or LLVM.