### PR TITLE
Fix some quadratic performance bugs

### DIFF
--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -520,7 +520,7 @@ Block::is_var_on_stack(const Variable* var) const
 	const Block* b = this;
 	while (b) {
 		ensure_vector_and_set_match(b->local_vars, b->local_var_set);
-		if (find_variable_in_set(b->local_var_set, var)) {
+		if (find_variable_in_set(b->local_var_set, var) != b->local_var_set.end()) {
 			return true;
 		}
 		b = b->parent;

--- a/src/Block.h
+++ b/src/Block.h
@@ -43,6 +43,7 @@
 
 #include <ostream>
 #include <vector>
+#include <set>
 #include <map>
 
 #include "Statement.h"
@@ -84,6 +85,7 @@ public:
 	std::vector<Statement *> stms;
 	std::vector<Statement *> deleted_stms;
 	std::vector<Variable *> local_vars;
+	mutable std::set<Variable *> local_var_set;
 	mutable std::map<std::string, enum eSimpleType> macro_tmp_vars;
 
 	std::string create_new_tmp_var(enum eSimpleType type) const;

--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -268,14 +268,16 @@ Bookkeeper::output_pointer_statistics(std::ostream &out)
 	int point_to_scalar = 0;
 	int point_to_struct = 0;
 	int point_to_pointer = 0;
-	const vector<const Variable*>& ptrs = FactPointTo::all_ptrs;
-	const vector<vector<const Variable*> >& aliases = FactPointTo::all_aliases;
-	for (i=0; i<ptrs.size(); i++) {
-		total_alias_cnt += aliases[i].size();
-		if (find_variable_in_set(aliases[i], FactPointTo::null_ptr) >= 0) {
+	const set<const Variable*>& ptrs = FactPointTo::all_ptrs;
+	const map<const Variable*, set<const Variable*> >& aliases = FactPointTo::all_aliases;
+	assert(ptrs.size() == aliases.size());
+	map<const Variable*, set<const Variable*> >::const_iterator j, end = aliases.end();
+	for (j = aliases.begin(); j != end; ++j) {
+		const Variable* var = j->first;
+		total_alias_cnt += j->second.size();
+		if (find_variable_in_set(j->second, FactPointTo::null_ptr) != j->second.end()) {
 			total_has_null_ptr++;
 		}
-		const Variable* var = ptrs[i];
 		const Type* t = var->type;
 		assert(t->eType == ePointer);
 		if (t->get_indirect_level() > 1) {

--- a/src/CGContext.cpp
+++ b/src/CGContext.cpp
@@ -631,14 +631,14 @@ CGContext::in_conflict(const Effect& eff) const
 void
 CGContext::find_reachable_frame_vars(vector<const Fact*>& facts, VariableSet& frame_vars) const
 {
-	size_t i, j;
+	size_t i;
 	for (i=0; i<facts.size(); i++) {
 		if (facts[i]->eCat == ePointTo) {
 			const FactPointTo* fp = (const FactPointTo*)(facts[i]);
-			for (j=0; j<fp->get_point_to_vars().size(); j++) {
-				const Variable* v = fp->get_point_to_vars()[j];
-				if (is_frame_var(v)) {
-					frame_vars.push_back(v);
+			set<const Variable*>::const_iterator j, end = fp->get_point_to_vars().end();
+			for (j = fp->get_point_to_vars().begin(); j != end; ++j) {
+				if (is_frame_var(*j)) {
+					frame_vars.push_back(*j);
 				}
 			}
 		}

--- a/src/Fact.cpp
+++ b/src/Fact.cpp
@@ -150,6 +150,17 @@ find_related_fact(const vector<Fact*>& facts, const Fact* new_fact)
     return 0;
 }
 
+const Fact*
+find_related_fact(const FactMap& facts, const Fact* new_fact)
+{
+    FactMap::key_type key = std::make_pair(new_fact->eCat, new_fact->get_var());
+    FactMap::const_iterator pos = facts.find(key);
+    if (pos != facts.end()) {
+        return pos->second;
+    }
+    return 0;
+}
+
 // TODO: we really need to free the memory properly while maintain the memory in compact
 // way, i.e., don't allocate a Fact object unless it's absolutely necessary
 bool

--- a/src/Fact.h
+++ b/src/Fact.h
@@ -34,6 +34,7 @@
 
 #include <ostream>
 #include <vector>
+#include <map>
 using namespace std;
 
 enum eFactCategory {
@@ -116,6 +117,9 @@ int find_fact(const FactVec& facts, const Fact* fact);
 /* find a specific type of fact (same variable most likely) from facts env */
 const Fact* find_related_fact(const FactVec& facts, const Fact* new_fact);
 const Fact* find_related_fact(const vector<Fact*>& facts, const Fact* new_fact);
+
+typedef std::map<std::pair<eFactCategory, const Variable *>, const Fact *> FactMap;
+const Fact* find_related_fact(const FactMap& facts, const Fact* new_fact);
 
 /* merge a fact into env */
 bool merge_fact(FactVec& facts, const Fact* new_fact);

--- a/src/FactMgr.cpp
+++ b/src/FactMgr.cpp
@@ -432,7 +432,7 @@ FactMgr::update_fact_for_return(const StatementReturn* sr, FactVec& inputs)
 void
 FactMgr::update_facts_for_dest(const FactVec& facts_in, FactVec& facts_out, const Statement* dest)
 {
-	size_t i, j;
+	size_t i;
 	vector<const Variable*> oos_vars;
 	const Function* func = dest->func;
 	assert(func);
@@ -450,8 +450,9 @@ FactMgr::update_facts_for_dest(const FactVec& facts_in, FactVec& facts_out, cons
 		}
 		if (f->eCat == ePointTo) {
 			const FactPointTo* fp = dynamic_cast<const FactPointTo*>(f);
-			for (j=0; j<fp->get_point_to_vars().size(); j++) {
-				const Variable* v = fp->get_point_to_vars()[j];
+			set<const Variable*>::iterator j, end = fp->get_point_to_vars().end();
+			for (j = fp->get_point_to_vars().begin(); j != end; ++j) {
+				const Variable* v = *j;
 				if (!FactPointTo::is_special_ptr(v) && func->is_var_oos(v, dest)) {
 					if (find_variable_in_set(oos_vars, v) == -1) {
 						oos_vars.push_back(v);

--- a/src/FactMgr.cpp
+++ b/src/FactMgr.cpp
@@ -513,6 +513,13 @@ void
 FactMgr::makeup_new_var_facts(vector<const Fact*>& old_facts, const vector<const Fact*>& new_facts)
 {
     size_t i;
+    // We will search the old facts repeatedly. Copy the entries to a map
+    // for faster lookup.
+    FactMap old_fact_map;
+    for (i=0; i<old_facts.size(); i++) {
+        const Fact* f = old_facts[i];
+        old_fact_map[std::make_pair(f->eCat, f->get_var())] = f;
+    }
     for (i=0; i<new_facts.size(); i++) {
 		const Fact* f = new_facts[i];
 		const Variable* v = f->get_var();
@@ -520,8 +527,9 @@ FactMgr::makeup_new_var_facts(vector<const Fact*>& old_facts, const vector<const
 			// if there are variable facts not present in old facts,
 			// mean they are variables created after old_facts,
 			// manually add them
-			if (find_related_fact(old_facts, f) == 0) {
+			if (find_related_fact(old_fact_map, f) == 0) {
 				FactMgr::add_new_var_fact(v, old_facts);
+				old_fact_map[std::make_pair(f->eCat, f->get_var())] = f;
 			}
 		}
 	}

--- a/src/FactPointTo.h
+++ b/src/FactPointTo.h
@@ -34,6 +34,8 @@
 
 #include <ostream>
 #include <vector>
+#include <set>
+#include <map>
 #include "Fact.h"
 
 class Variable;
@@ -53,8 +55,10 @@ class FactPointTo : public Fact
 public:
  	static FactPointTo *make_fact(const Variable* v);
 	static FactPointTo *make_fact(const Variable* v, const vector<const Variable*>& set);
+	static FactPointTo *make_fact(const Variable* v, const set<const Variable*>& set);
 	static FactPointTo *make_fact(const Variable* v, const Variable* point_to);
 	static vector<const Fact*> make_facts(vector<const Variable*> vars, const vector<const Variable*>& set);
+	static vector<const Fact*> make_facts(vector<const Variable*> vars, const set<const Variable*>& set);
 	static vector<const Fact*> make_facts(vector<const Variable*> vars, const Variable* point_to);
 	static void doFinalization();
 
@@ -62,7 +66,7 @@ public:
 	virtual ~FactPointTo(void);
 
 	virtual const Variable* get_var(void) const { return var;};
-	const vector<const Variable*>& get_point_to_vars(void) const { return point_to_vars; };
+	const set<const Variable*>& get_point_to_vars(void) const { return point_to_vars; };
 
 	bool is_null(void) const;
 	bool is_tbd_only(void) const;
@@ -110,16 +114,17 @@ public:
 	static const Variable* garbage_ptr;
 	static const Variable* tbd_ptr;
 
-	static vector<const Variable*> all_ptrs;
-	static vector<vector<const Variable*> > all_aliases;
+	static set<const Variable*> all_ptrs;
+	static map<const Variable*, set<const Variable*> > all_aliases;
 private:
 	FactPointTo(const Variable* v, const vector<const Variable*>& set);
+	FactPointTo(const Variable* v, const set<const Variable*>& set);
 	FactPointTo(const Variable* v, const Variable* point_to);
 
 	const Variable* var;
-	vector<const Variable*> point_to_vars;
+	set<const Variable*> point_to_vars;
 
-	static void update_ptr_aliases(const vector<Fact*>& facts, vector<const Variable*>& ptrs, vector<vector<const Variable*> >& aliases);
+	static void update_ptr_aliases(const vector<Fact*>& facts, set<const Variable*>& ptrs, map<const Variable*, set<const Variable*> >& aliases);
 
 	// unimplement
 	FactPointTo(const FactPointTo& f);

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -152,12 +152,9 @@ Function::is_var_on_stack(const Variable* var, const Statement* stm) const
         }
     }
 	const Block* b = stm->parent;
-	while (b) {
-		if (find_variable_in_set(b->local_vars, var) != -1) {
-			return true;
-		}
-		b = b->parent;
-	}
+    if (b && b->is_var_on_stack(var)) {
+        return true;
+    }
     return false;
 }
 

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -98,6 +98,21 @@ int find_variable_in_set(const vector<Variable*>& set, const Variable* v)
     return -1;
 }
 
+bool find_variable_in_set(const set<Variable*>& vars, const Variable* v)
+{
+    const Variable *target = v;
+    while (target != NULL) {
+        // Cast away const while searching because the container's elements
+        // are non-const :-(
+        const set<Variable*>::iterator pos = vars.find((Variable *) target);
+        if (pos != vars.end()) {
+            return true;
+        }
+        target = target->field_var_of;
+    }
+    return false;
+}
+
 int find_field_variable_in_set(const vector<const Variable*>& set, const Variable* v)
 {
     size_t i;

--- a/src/Variable.h
+++ b/src/Variable.h
@@ -186,13 +186,16 @@ int HashVariable(Variable *var, std::ostream *pOut);
 
 int find_variable_in_set(const vector<const Variable*>& set, const Variable* v);
 int find_variable_in_set(const vector<Variable*>& set, const Variable* v);
-bool find_variable_in_set(const set<Variable*>& set, const Variable* v);
+set<const Variable*>::const_iterator find_variable_in_set(const set<const Variable*>& set, const Variable* v);
+set<Variable*>::const_iterator find_variable_in_set(const set<Variable*>& set, const Variable* v);
 int find_field_variable_in_set(const vector<const Variable*>& set, const Variable* v);
+set<const Variable*>::const_iterator find_field_variable_in_set(const set<const Variable*>& set, const Variable* v);
 bool is_variable_in_set(const vector<const Variable*>& set, const Variable* v);
+bool is_variable_in_set(const set<const Variable*>& set, const Variable* v);
 bool add_variable_to_set(vector<const Variable*>& set, const Variable* v);
 bool add_variables_to_set(vector<const Variable*>& set, const vector<const Variable*>& new_set);
-bool equal_variable_sets(const vector<const Variable*>& set1, const vector<const Variable*>& set2);
-bool sub_variable_sets(const vector<const Variable*>& set1, const vector<const Variable*>& set2);
+bool equal_variable_sets(const set<const Variable*>& set1, const set<const Variable*>& set2);
+bool sub_variable_sets(const set<const Variable*>& set1, const set<const Variable*>& set2);
 void combine_variable_sets(const vector<const Variable*>& set1, const vector<const Variable*>& set2, vector<const Variable*>& set_all);
 void remove_field_vars(vector<const Variable*>& set);
 

--- a/src/Variable.h
+++ b/src/Variable.h
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <set>
 using namespace std;
 
 #include "Effect.h"
@@ -185,6 +186,7 @@ int HashVariable(Variable *var, std::ostream *pOut);
 
 int find_variable_in_set(const vector<const Variable*>& set, const Variable* v);
 int find_variable_in_set(const vector<Variable*>& set, const Variable* v);
+bool find_variable_in_set(const set<Variable*>& set, const Variable* v);
 int find_field_variable_in_set(const vector<const Variable*>& set, const Variable* v);
 bool is_variable_in_set(const vector<const Variable*>& set, const Variable* v);
 bool add_variable_to_set(vector<const Variable*>& set, const Variable* v);


### PR DESCRIPTION
When generating large functions, I noticed that Csmith can be excessively slow. For example, `csmith --max-funcs 1 --nomain --max-block-size 20 --seed 827638045` takes 4 minutes on my machine, and `csmith --max-funcs 1 --nomain --max-block-size 15 --seed 1229442881` even 7 minutes.

I suspected the use of quadratic algorithms, and profiling confirmed that in many places vectors were used to represent sets and searched linearly many times.

This series of patches fixes the worst of these cases by replacing vectors with sets. This brings both of the examples down to 1 minute each. (Which still seems a lot for generating 4000 lines of code.)