### PR TITLE
Fix preprocessor check for inline asm

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -64,7 +64,7 @@ static inline unsigned long read_time(void)
 	asm volatile("mftb %0" : "=r" (a));
 	return a;
 }
-#  elif defined(WIN32)
+#  elif defined(_MSC_VER) && defined(_M_IX86)
 static unsigned __int64 read_time(void)
 {
 	unsigned l, h;


### PR DESCRIPTION
With MSVC [inline asm](https://docs.microsoft.com/en-us/cpp/assembler/inline/inline-assembler) is only available when compiling for x86. [WIN32](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros) is defined for all of x86, x64, and ARM. This checks for MSVC and x86 instead.