### PR TITLE
Delete unnecessary null pointer checks

### DIFF
--- a/src/DepthSpec.h
+++ b/src/DepthSpec.h
@@ -91,14 +91,14 @@ enum dType {
 
 #define DEPTH_GUARD_BY_DEPTH_RETURN_DEL1(d, t1, rv) \
 	if (DepthSpec::depth_guard_by_depth(d) != GOOD_DEPTH) { \
-		if (t1) delete t1; \
+		delete t1; \
 		return rv; \
 	}
 
 #define DEPTH_GUARD_BY_DEPTH_RETURN_DEL2(d, t1, t2, rv) \
 	if (DepthSpec::depth_guard_by_depth(d) != GOOD_DEPTH) { \
-		if (t1) delete t1; \
-		if (t2) delete t2; \
+		delete t1; \
+		delete t2; \
 		return rv; \
 	}
 

--- a/src/Enumerator.h
+++ b/src/Enumerator.h
@@ -148,8 +148,7 @@ Enumerator<Name>::~Enumerator()
 {
 	typename map<Name, EnumObject*>::iterator i;
 	for (i = objs_.begin(); i != objs_.end(); ++i) {
-		if ((*i).second != NULL)
-			delete (*i).second;
+		delete i->second;
 	}
 	objs_.clear();
 }

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -874,10 +874,7 @@ OutputFunctions(std::ostream &out)
 int
 Function::deleteFunction(Function* func)
 {
-	if (func) {
-		delete func;
-		func = 0;
-	}
+	delete func;
 	return 0;
 }
 

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -192,9 +192,7 @@ GroupProbElem::~GroupProbElem()
 {
 	std::map<ProbName, SingleProbElem*>::iterator i;
 	for (i = probs_.begin(); i != probs_.end(); ++i) {
-		SingleProbElem *elem = (*i).second;
-		assert(elem);
-		delete elem;
+		delete i->second;
 	}
 	probs_.clear();
 }
@@ -381,10 +379,8 @@ Probabilities::GetInstance()
 void
 Probabilities::DestroyInstance()
 {
-	if (Probabilities::instance_) {
-		delete Probabilities::instance_;
-		Probabilities::instance_ = NULL;
-	}
+	delete instance_;
+	instance_ = NULL;
 }
 
 void

--- a/src/RandomNumber.cpp
+++ b/src/RandomNumber.cpp
@@ -174,9 +174,7 @@ RandomNumber::doFinalization()
 	for (unsigned int i = 0; i < count; ++i) {
 		RNDNUM_GENERATOR rImpl = static_cast<RNDNUM_GENERATOR>(i);
 		generator = instance_->generators_[rImpl];
-		if (generator != NULL) {
-			delete generator;
-		}
+		delete generator;
 	}
 	delete instance_;
 }

--- a/src/SimpleDeltaSequence.cpp
+++ b/src/SimpleDeltaSequence.cpp
@@ -184,8 +184,7 @@ SimpleDeltaSequence::clear()
 {
 	std::map<int, SimpleDeltaSequence::ValuePair*>::iterator i;
 	for (i = seq_map_.begin(); i != seq_map_.end(); ++i) {
-		assert((*i).second);
-		delete ((*i).second);
+		delete i->second;
 	}
 	seq_map_.clear();
 }

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -474,10 +474,7 @@ Variable::~Variable(void)
 	for(i = field_vars.begin(); i != field_vars.end(); ++i)
 		delete (*i);
 	field_vars.clear();
-	if (init) {
-		delete init;
-		init = NULL;
-	}
+	delete init;
 }
 
 // --------------------------------------------------------------


### PR DESCRIPTION
[The C++ programming language tolerates the passing of null pointers for delete expressions](https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null "Do I need to check for null before delete p?").

* Thus omit extra checks at a few places.
* Remove also the resetting of two variables.
* The source code could be simplified a bit for three iterators.