### PR TITLE
Added support for computed goto extension

### DIFF
--- a/src/Block.h
+++ b/src/Block.h
@@ -80,6 +80,10 @@ public:
     Block* random_parent_block(void);
 
 	int block_size() { return block_size_; }
+	std::vector<string> addr_labels;
+	std::vector<string> try_only_labels;
+	void print_label_addr_array(std::ostream&, int) const;
+
 	// These are currently accessed directly.
 	std::vector<Statement *> stms;
 	std::vector<Statement *> deleted_stms;

--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -199,6 +199,7 @@ DEFINE_GETTER_SETTER_BOOL(const_struct_union_fields);
 DEFINE_GETTER_SETTER_BOOL(lang_cpp);
 DEFINE_GETTER_SETTER_BOOL(cpp11);
 DEFINE_GETTER_SETTER_BOOL(fast_execution);
+DEFINE_GETTER_SETTER_BOOL(computed_goto);
 
 void
 CGOptions::set_default_builtin_kinds()
@@ -313,6 +314,7 @@ CGOptions::set_default_settings(void)
   fast_execution(false);
 
 	set_default_builtin_kinds();
+	computed_goto(false);
 }
 
 // Add options necessary for cpp 

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -363,6 +363,8 @@ public:
 	static bool signed_char_index(void);
 	static bool signed_char_index(bool p);
 
+	static bool computed_goto(void);
+	static bool computed_goto(bool p);
 	/////////////////////////////////////////////////////////
 	static void set_default_settings(void);
 
@@ -579,6 +581,7 @@ private:
 	static bool no_return_dead_ptr_;
 	static bool hash_value_printf_;
 	static bool signed_char_index_;
+	static bool computed_goto_;
 	static std::string	dump_default_probabilities_;
 	static std::string	dump_random_probabilities_;
 	static std::string	probability_configuration_;

--- a/src/DefaultProgramGenerator.cpp
+++ b/src/DefaultProgramGenerator.cpp
@@ -91,7 +91,6 @@ void
 DefaultProgramGenerator::goGenerator()
 {
 	output_mgr_->OutputHeader(argc_, argv_, seed_);
-
 	GenerateAllTypes();
 	GenerateFunctions();
 	output_mgr_->Output();

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -176,6 +176,9 @@ static void print_help()
 	cout << "  --inline-function | --no-inline-function: enable | disable inline attributes on generated functions." << endl << endl;
 	cout << "  --inline-function-prob <num>: set the probability of each function being marked as inline (default is 50)." << endl << endl;
 
+	//GCC C extensions
+	cout << "  --computed-goto | --no-computed-goto: enable | disable computed goto extension (disable by default)." << endl << endl;
+
 	// numbered controls
 	cout << "  --max-array-dim <num>: limit array dimensions to <num>. (default 3)" << endl << endl;
 	cout << "  --max-array-len-per-dim <num>: limit array length per dimension to <num> (default 10)." << endl << endl;
@@ -847,6 +850,16 @@ main(int argc, char **argv)
 
 		if (strcmp (argv[i], "--jumps") == 0) {
 			CGOptions::jumps(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--computed-goto") == 0) {
+			CGOptions::computed_goto(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-computed-goto") == 0) {
+			CGOptions::computed_goto(false);
 			continue;
 		}
 

--- a/src/StatementGoto.cpp
+++ b/src/StatementGoto.cpp
@@ -260,7 +260,11 @@ StatementGoto::Output(std::ostream &out, FactMgr* /*fm*/, int indent) const
 	out << ")";
 	outputln(out);
 	output_tab(out, indent+1);
-	out << "goto " << label << ";";
+
+	if(CGOptions::computed_goto())
+		out << "goto " << other_name_for_label << ";";
+	else
+		out << "goto " << label << ";";
 	outputln(out);
 }
 
@@ -416,6 +420,27 @@ StatementGoto::doFinalization(void)
 	stm_labels.clear();
 }
 
+void
+StatementGoto::change_label(std::vector<string> addr_labels) const{
+	string find_label="";
+	find_label+="&&";
+	find_label+=label;
+	auto it = std::find(addr_labels.begin(),addr_labels.end(),find_label);
+	int index;
+	if(it == addr_labels.end()){
+		assert ("LABEL NOT FOUND");
+	}
+	else{
+	index = std::distance (addr_labels.begin(),it);
+	}
+	std::stringstream ss;
+	ss.clear();
+	ss<< "*target[";
+	ss<<index;
+	ss<<"]";
+	other_name_for_label="";
+	other_name_for_label=ss.str();
+}
 ///////////////////////////////////////////////////////////////////////////////
 
 // Local Variables:

--- a/src/StatementGoto.h
+++ b/src/StatementGoto.h
@@ -72,6 +72,9 @@ public:
 	std::string label;
 	std::vector<const Variable*> init_skipped_vars;
 	static std::map<const Statement*, std::string> stm_labels;
+
+	mutable std::string other_name_for_label;
+	void change_label(std::vector<string> addr_labels) const;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This pull request contain implementation of computed goto extension.

Command line options for computed goto are as below - 
1) --computed-goto   : Enables computed goto extension
2) --no-computed-goto   : Disbales computed goto exxtension

By default, this extension is disabled.