### PR TITLE
Fix following warnings seen with GCC 9:

### DIFF
--- a/src/CGContext.h
+++ b/src/CGContext.h
@@ -175,7 +175,6 @@ private:
 	// TODO: move `Function::...' to here?
 
 private:
-	CGContext &operator=(const CGContext &cgc);	// unimplementable
 	void sanity_check(void);
 	static const CGContext empty_context;
 };

--- a/src/DefaultRndNumGenerator.cpp
+++ b/src/DefaultRndNumGenerator.cpp
@@ -101,7 +101,7 @@ DefaultRndNumGenerator::get_prefixed_name(const std::string &name)
 }
 
 void
-DefaultRndNumGenerator::add_number(int v, int bound, int k)
+DefaultRndNumGenerator::add_number(int, int, int)
 {
 }
 

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -833,7 +833,6 @@ void
 Probabilities::set_prob_filter(ProbName pname)
 {
 	prob_filters_[pname] = new ProbabilityFilter(pname);
-	set_extra_filters(pname);
 }
 
 void
@@ -853,11 +852,6 @@ Probabilities::unregister_extra_filter(ProbName pname, Filter *filter)
 	assert(impl);
 	assert(impl->extra_filters_[pname] == filter);
 	impl->extra_filters_[pname] = NULL;
-}
-
-void
-Probabilities::set_extra_filters(ProbName pname)
-{
 }
 
 bool

--- a/src/Probabilities.h
+++ b/src/Probabilities.h
@@ -413,8 +413,6 @@ private:
 
 	void set_prob_filter(ProbName pname);
 
-	void set_extra_filters(ProbName pname);
-
 	bool check_extra_filter(ProbName pname, int v);
 
 	void initialize_single_probs();


### PR DESCRIPTION
```/home/marxin/Programming/csmith/src/DefaultRndNumGenerator.cpp: In member function ‘void DefaultRndNumGenerator::add_number(int, int, int)’:
/home/marxin/Programming/csmith/src/DefaultRndNumGenerator.cpp:104:40: warning: unused parameter ‘v’ [-Wunused-parameter]
  104 | DefaultRndNumGenerator::add_number(int v, int bound, int k)
      |                                    ~~~~^
/home/marxin/Programming/csmith/src/DefaultRndNumGenerator.cpp:104:47: warning: unused parameter ‘bound’ [-Wunused-parameter]
  104 | DefaultRndNumGenerator::add_number(int v, int bound, int k)
      |                                           ~~~~^~~~~
/home/marxin/Programming/csmith/src/DefaultRndNumGenerator.cpp:104:58: warning: unused parameter ‘k’ [-Wunused-parameter]
  104 | DefaultRndNumGenerator::add_number(int v, int bound, int k)
      |                                                      ~~~~^
/home/marxin/Programming/csmith/src/Probabilities.cpp: In member function ‘void Probabilities::set_extra_filters(ProbName)’:
/home/marxin/Programming/csmith/src/Probabilities.cpp:859:43: warning: unused parameter ‘pname’ [-Wunused-parameter]
  859 | Probabilities::set_extra_filters(ProbName pname)
      |                                  ~~~~~~~~~^~~~~
/home/marxin/Programming/csmith/src/VariableSelector.cpp: In static member function ‘static bool VariableSelector::is_eligible_var(const Variable*, int, Effect::Access, const CGContext&)’:
/home/marxin/Programming/csmith/src/VariableSelector.cpp:241:30: warning: implicitly-declared ‘CGContext::CGContext(const CGContext&)’ is deprecated [-Wdeprecated-copy]
  241 |   CGContext cg_tmp(cg_context);
      |                              ^
In file included from /home/marxin/Programming/csmith/src/Expression.h:45,
                 from /home/marxin/Programming/csmith/src/Lhs.h:37,
                 from /home/marxin/Programming/csmith/src/StatementAssign.h:40,
                 from /home/marxin/Programming/csmith/src/Type.h:48,
                 from /home/marxin/Programming/csmith/src/Variable.h:51,
                 from /home/marxin/Programming/csmith/src/VariableSelector.h:38,
                 from /home/marxin/Programming/csmith/src/VariableSelector.cpp:38:
/home/marxin/Programming/csmith/src/CGContext.h:178:13: note: because ‘CGContext’ has user-provided ‘CGContext& CGContext::operator=(const CGContext&)’
  178 |  CGContext &operator=(const CGContext &cgc); // unimplementable
      |             ^~~~~~~~
```