### PR TITLE
Added support for signed & unsigned integer of size 128 bits and generation of binary constants

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -202,6 +202,7 @@ DEFINE_GETTER_SETTER_BOOL(label_attr_flag);
 DEFINE_GETTER_SETTER_BOOL(var_attr_flag);
 DEFINE_GETTER_SETTER_BOOL(Int128);
 DEFINE_GETTER_SETTER_BOOL(UInt128);
+DEFINE_GETTER_SETTER_BOOL(binary_constant);
 
 void
 CGOptions::set_default_builtin_kinds()
@@ -315,6 +316,7 @@ CGOptions::set_default_settings(void)
 	set_default_builtin_kinds();
 	Int128(false);
 	UInt128(false);
+	binary_constant(false);
 }
 
 // Add options necessary for cpp 

--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -200,6 +200,8 @@ DEFINE_GETTER_SETTER_BOOL(func_attr_flag);
 DEFINE_GETTER_SETTER_BOOL(type_attr_flag);
 DEFINE_GETTER_SETTER_BOOL(label_attr_flag);
 DEFINE_GETTER_SETTER_BOOL(var_attr_flag);
+DEFINE_GETTER_SETTER_BOOL(Int128);
+DEFINE_GETTER_SETTER_BOOL(UInt128);
 
 void
 CGOptions::set_default_builtin_kinds()
@@ -311,6 +313,8 @@ CGOptions::set_default_settings(void)
   fast_execution(false);
 
 	set_default_builtin_kinds();
+	Int128(false);
+	UInt128(false);
 }
 
 // Add options necessary for cpp 

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -475,6 +475,9 @@ public:
 
 	static bool UInt128(void);
 	static bool UInt128(bool p);
+
+	static bool binary_constant(void);
+	static bool binary_constant(bool p);
 private:
 	static bool enabled_builtin_kind(const string &kind);
 
@@ -624,6 +627,7 @@ private:
 	static bool	var_attr_flag_;
 	static bool     Int128_;
 	static bool     UInt128_;
+	static bool	binary_constant_;
 private:
 	CGOptions(void);
 	CGOptions(CGOptions &cgo);

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -469,6 +469,12 @@ public:
 
 	static bool var_attr_flag(void);
 	static bool var_attr_flag(bool p);
+
+	static bool Int128(void);
+	static bool Int128(bool p);
+
+	static bool UInt128(void);
+	static bool UInt128(bool p);
 private:
 	static bool enabled_builtin_kind(const string &kind);
 
@@ -616,6 +622,8 @@ private:
 	static bool	type_attr_flag_;
 	static bool	label_attr_flag_;
 	static bool	var_attr_flag_;
+	static bool     Int128_;
+	static bool     UInt128_;
 private:
 	CGOptions(void);
 	CGOptions(CGOptions &cgo);

--- a/src/Constant.cpp
+++ b/src/Constant.cpp
@@ -124,6 +124,15 @@ GenerateRandomIntConstant(void)
 
 // --------------------------------------------------------------
 static string
+GenerateRandomInt128Constant(void)
+{
+	string val;
+	val = "0x" + RandomHexDigits( 16 ) ;
+	return val;
+}
+
+// --------------------------------------------------------------
+static string
 GenerateRandomShortConstant(void)
 {
 	string val;
@@ -380,6 +389,8 @@ GenerateRandomConstant(const Type* type)
 			case eULong:     v = GenerateRandomLongConstant();		break;
 			case eULongLong: v = GenerateRandomLongLongConstant();		break;
 			case eFloat:     v = GenerateRandomFloatHexConstant();		break;
+			case eInt128:    v = GenerateRandomInt128Constant();		break;
+			case eUInt128:   v = GenerateRandomInt128Constant();		break;
 			// case eDouble:    v = GenerateRandomFloatConstant();		break;
 			default:
 				assert(0 && "Unsupported type!");

--- a/src/Constant.cpp
+++ b/src/Constant.cpp
@@ -96,12 +96,28 @@ Constant::clone() const
 	return new Constant(*this);
 }
 
+//--------------------------------------------------------------
+string HexToBinary(string val)
+{
+	std::ostringstream oss;
+	string ToBinary[] = {"0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111", "1000", "1001", "1010", "1011", "1100", "1101", "1110", "1111"};
+	for (unsigned int i = 0; i < val.size(); i++) {
+		if ((val[i] - '0') < 16)
+			oss << ToBinary[val[i] - '0'];
+		else
+			oss << ToBinary[val[i] - '7'];
+	}
+	return oss.str();
+}
+
 // --------------------------------------------------------------
 static string
 GenerateRandomCharConstant(void)
 {
 	string ch;
-	if (CGOptions::ccomp() || !CGOptions::longlong())
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+		ch = string("0b") + HexToBinary(RandomHexDigits(2));
+	} else if (CGOptions::ccomp() || !CGOptions::longlong())
 		ch = string("0x") + RandomHexDigits(2);
 	else
 		ch = string("0x") + RandomHexDigits(2) + "L";
@@ -114,7 +130,9 @@ GenerateRandomIntConstant(void)
 {
 	string val;
 	// Int constant - Max 8 Hex digits on 32-bit platforms
-	if (CGOptions::ccomp() || !CGOptions::longlong())
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+		val = string("0b") + HexToBinary(RandomHexDigits( 8 ));
+	} else if (CGOptions::ccomp() || !CGOptions::longlong())
 		val = "0x" + RandomHexDigits( 8 );
 	else
 		val = "0x" + RandomHexDigits( 8 ) + "L";
@@ -127,7 +145,10 @@ static string
 GenerateRandomInt128Constant(void)
 {
 	string val;
-	val = "0x" + RandomHexDigits( 16 ) ;
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+		val = string("0b") + HexToBinary(RandomHexDigits( 16 ));
+	} else
+		val = "0x" + RandomHexDigits( 16 ) ;
 	return val;
 }
 
@@ -137,7 +158,9 @@ GenerateRandomShortConstant(void)
 {
 	string val;
 	// Short constant - Max 4 Hex digits on 32-bit platforms
-	if (CGOptions::ccomp() || !CGOptions::longlong())
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+                val = string("0b") + HexToBinary(RandomHexDigits( 4 ));
+	} else if (CGOptions::ccomp() || !CGOptions::longlong())
 		val = "0x" + RandomHexDigits( 4 );
 	else
 		val = "0x" + RandomHexDigits( 4 ) + "L";
@@ -151,7 +174,9 @@ GenerateRandomLongConstant(void)
 {
 	string val;
 	// Long constant - Max 8 Hex digits on 32-bit platforms
-	if (!CGOptions::longlong())
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+                val = string("0b") + HexToBinary(RandomHexDigits( 8 ));
+	} else if (!CGOptions::longlong())
 		val = "0x" + RandomHexDigits( 8 );
 	else
 		val = "0x" + RandomHexDigits( 8 ) + "L";
@@ -162,8 +187,12 @@ GenerateRandomLongConstant(void)
 static string
 GenerateRandomLongLongConstant(void)
 {
+	string val;
 	// Long constant - Max 8 Hex digits on 32-bit platforms
-	string val = "0x" + RandomHexDigits( 16 ) + "LL";
+	if (CGOptions::binary_constant() && rnd_flipcoin(pBinaryConstProb)) {
+		val = string("0b") + HexToBinary(RandomHexDigits( 16 )) + "LL";
+	} else
+		val = "0x" + RandomHexDigits( 16 ) + "LL";
 	return val;
 }
 

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -699,6 +699,20 @@ Probabilities::set_default_simple_types_prob()
 		SET_SINGLE_NAME("char_prob", Char, 0);
 	}
 
+	if (CGOptions::Int128()) {
+		SET_SINGLE_NAME("Int128_prob", Int128, 1);
+	}
+	else {
+		SET_SINGLE_NAME("Int128_prob", Int128, 0);
+	}
+
+	if (CGOptions::UInt128()) {
+		SET_SINGLE_NAME("UInt128_prob", UInt128, 1);
+	}
+	else {
+		SET_SINGLE_NAME("UInt128_prob", UInt128, 0);
+	}
+
 	SET_SINGLE_NAME("int_prob", Int, 1);
 	SET_SINGLE_NAME("short_prob", Short, 1);
 

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -513,6 +513,9 @@ Probabilities::set_single_name_maps()
 
 	//for choosing variable attributes
 	set_single_name("var_attr_flag", pVarAttrProb);
+
+	//for choosing binary constants
+        set_single_name("binary_constant", pBinaryConstProb);
 }
 
 void
@@ -558,6 +561,7 @@ Probabilities::initialize_single_probs()
 	m[pTypeAttrProb] = 50;
 	m[pLabelAttrProb] = 30;
 	m[pVarAttrProb] = 30;
+	m[pBinaryConstProb] = 3;
 
 	if (CGOptions::volatiles())
 		m[pRegularVolatileProb] = 50;

--- a/src/Probabilities.h
+++ b/src/Probabilities.h
@@ -139,6 +139,8 @@ enum ProbName {
 	pULongProb,
 	pULongLongProb,
 	pFloatProb,
+	pInt128Prob,
+	pUInt128Prob,
 
 	// for safe math ops
 	pSafeOpsSizeProb,
@@ -240,6 +242,12 @@ enum ProbName {
 
 #define VarAttrProb \
 	Probabilities::get_prob(pVarAttrProb)
+
+#define Int128Prob \
+	Probabilities::get_prob(pInt128Prob)
+
+#define UInt128Prob \
+	Probabilities::get_prob(pUInt128Prob)
 
 //////////////////////////////////////////////////
 #define UNARY_OPS_PROB_FILTER \

--- a/src/Probabilities.h
+++ b/src/Probabilities.h
@@ -154,6 +154,7 @@ enum ProbName {
 	pTypeAttrProb,
 	pLabelAttrProb,
 	pVarAttrProb,
+	pBinaryConstProb,
 
 };
 
@@ -248,6 +249,9 @@ enum ProbName {
 
 #define UInt128Prob \
 	Probabilities::get_prob(pUInt128Prob)
+
+#define BinaryConstProb \
+        Probabilities::get_prob(pBinaryConstProb)
 
 //////////////////////////////////////////////////
 #define UNARY_OPS_PROB_FILTER \

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -215,6 +215,8 @@ static void print_help()
 	cout << " --label-attributes | --no-label-attributes: enable | disable generate common label attributes (disabled by default)." << endl << endl;
 	cout << " --variable-attributes | --no-variable-attributes: enable | disable generate common variable attributes (disabled by default)." << endl << endl;
 	cout << " --compiler-attributes | --no-compiler-attributes: enable | disable generate function, type, label and variable attributes (disabled by default)." << endl << endl;
+	cout << "  --int128 | --no-int128: enable | disable generate __int128 as datatype extension (disabled by default)." << endl << endl;
+	cout << "  --uint128 | --no-uint128: enable | disable generate unsigned __int128 as datatype extension (disabled by default)." << endl << endl;
 
 }
 
@@ -858,6 +860,26 @@ main(int argc, char **argv)
                         CGOptions::var_attr_flag(false);
                         continue;
                 }
+
+		if (strcmp (argv[i], "--int128") == 0) {
+			CGOptions::Int128(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-int128") == 0) {
+			CGOptions::Int128(false);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--uint128") == 0) {
+			CGOptions::UInt128(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-uint128") == 0) {
+			CGOptions::UInt128(false);
+			continue;
+		}
 
 		if (strcmp (argv[i], "--max-array-dim") ==0 ) {
 			unsigned long dim;

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -217,6 +217,7 @@ static void print_help()
 	cout << " --compiler-attributes | --no-compiler-attributes: enable | disable generate function, type, label and variable attributes (disabled by default)." << endl << endl;
 	cout << "  --int128 | --no-int128: enable | disable generate __int128 as datatype extension (disabled by default)." << endl << endl;
 	cout << "  --uint128 | --no-uint128: enable | disable generate unsigned __int128 as datatype extension (disabled by default)." << endl << endl;
+	cout << "  --binary-constant | --no-binary-constant: enable | disable generate binary constant (disabled by default)." << endl << endl;
 
 }
 
@@ -878,6 +879,16 @@ main(int argc, char **argv)
 
 		if (strcmp (argv[i], "--no-uint128") == 0) {
 			CGOptions::UInt128(false);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--binary-constant") == 0) {
+			CGOptions::binary_constant(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-binary-constant") == 0) {
+			CGOptions::binary_constant(false);
 			continue;
 		}
 

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -451,6 +451,12 @@ Type::get_type_from_string(const string &type_string)
 	else if (type_string == "Float") {
 		return &Type::get_simple_type(eFloat);
 	}
+	else if (type_string == "Int128") {
+		return &Type::get_simple_type(eInt128);
+	}
+	else if (type_string == "UInt128") {
+		return &Type::get_simple_type(eUInt128);
+	}
 
 	assert(0 && "Unsupported type string!");
 	return NULL;
@@ -1446,6 +1452,8 @@ Type::to_unsigned(void) const
 			case eShort: return &get_simple_type(eUShort);
 			case eLong: return &get_simple_type(eULong);
 			case eLongLong: return &get_simple_type(eULongLong);
+			case eInt128: return &get_simple_type(eInt128);
+			case eUInt128: return &get_simple_type(eUInt128);
 			default:
 				break;
 		}
@@ -1613,7 +1621,9 @@ Type::SizeInBytes(void) const
 		case eULong:	return 4;
 		case eULongLong:return 8;
 		case eFloat:	return 4;
-//		case eDouble:	return 8;
+		case eInt128: 		return 16;
+		case eUInt128: 		return 16;
+//              case eDouble:   return 8;
 		}
 		break;
 	case eUnion: {
@@ -1742,6 +1752,10 @@ Type::Output(std::ostream &out) const
 			out << "void";
 		} else if (this->simple_type == eFloat) {
 		        out << "float";
+		} else if (this->simple_type == eInt128) {
+			out << "__int" << (SizeInBytes() * 8);
+		} else if (this->simple_type == eUInt128) {
+			out << "unsigned __int" << (SizeInBytes() * 8);
 		} else {
 			out << (is_signed() ? "int" : "uint");
 			out << (SizeInBytes() * 8);

--- a/src/Type.h
+++ b/src/Type.h
@@ -83,8 +83,10 @@ enum eSimpleType
 	eFloat,
 	// eDouble,
 	eULongLong,
+	eInt128,
+	eUInt128,
 };
-#define MAX_SIMPLE_TYPES ((eSimpleType) (eULongLong+1))
+#define MAX_SIMPLE_TYPES ((eSimpleType) (eUInt128+1))
 
 enum eMatchType
 {


### PR DESCRIPTION
This PR adds support for generation of signed and unsigned int of 128 bits. `__int128` is GCC C Extension. Similar to other PR, the generation of this extension is disabled by default.

@jxyang - Please review and suggest changes.