### PR TITLE
guard use of printf with #ifndef NO_PRINTF in csmith_minimal.h

### DIFF
--- a/runtime/csmith_minimal.h
+++ b/runtime/csmith_minimal.h
@@ -102,9 +102,11 @@ transparent_crc_bytes (char *ptr, int nbytes, char* vname, int flag)
   for (i=0; i<nbytes; i++) {
     crc32_context += ptr[i];
   }
+#ifndef NO_PRINTF
   if (flag) {
     printf("...checksum after hashing %s : %lX\n", vname, crc32_context ^ 0xFFFFFFFFUL);
   }
+#endif
 }
 
 #ifdef NO_PRINTF


### PR DESCRIPTION
if -DCSMITH_MINIMAL -DNO_PRINTF is specified, csmith uses getchar instead of printf, and removes most of the printf-based logging. However, this one line was kept for some reason. Since it seems to just contain logging data, I added the ifdef guard like transparent_crc has.