### PR TITLE
add prototypes for fabs and fabsf to safe_math.h

### DIFF
--- a/runtime/safe_math.m4
+++ b/runtime/safe_math.m4
@@ -352,6 +352,8 @@ FUNC_NAME(div_func_$1_f_f)($1 sf1, $1 sf2 LOG_INDEX)
 ')
 
 #ifdef __STDC__
+float fabsf(float);
+double fabs(double);
 safe_float_math(float,f,FLT_MAX,0x1.0p-28f,0x1.0p-49f)
 safe_float_math(double,,DBL_MAX,0x1.0p-924,0x1.0p-974)
 #else


### PR DESCRIPTION
When -DCSMITH_MINIMAL is set, these functions are used but not declared, which creates a syntax error according to ISO C. Here we add them to the minimal set of standard library functions that are required to be defined when -DCSMITH_MINIMAL is set. A better solution might be to implement them ourselves rather than relying on the standard library version, but I wasn't sure the right way to go about doing that in keeping with the way the rest of the safe math functions are generated, so I just went with this approach.