### PR TITLE
Add command line swithces for platform info and remove creation of platform.info file

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -329,10 +329,9 @@ CGOptions::fix_options_for_cpp(void)
 }
 
 /*
-   looking for the platform info file in the working directory
-   and load platform specific information. If not found, use
-   info from the platform that Csmith is running, and output them
-   to the file
+   looks for a platform info file in the working directory
+   and loads platform specific information. If not found, use
+   info from the platform that Csmith is running.
 */
 void
 CGOptions::set_platform_specific_options(void)
@@ -341,9 +340,6 @@ CGOptions::set_platform_specific_options(void)
 	const char* ptr_str = "pointer size = ";
 	ifstream conf(PLATFORM_CONFIG_FILE);
 	if (conf.fail()) {
-		ofstream conf(PLATFORM_CONFIG_FILE);
-		conf << int_str << sizeof(int) << endl;
-		conf << ptr_str << sizeof(int*) << endl;
 		int_size(sizeof(int));
 		pointer_size(sizeof(int*));
 		conf.close();

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -343,6 +343,10 @@ static void print_advanced_help()
 	cout << "  --no-hash-value-printf: do not emit printf on the index of an array" << endl << endl;
 	cout << "  --no-signed-char-index: do not allow a var of type char to be used as array index" << endl << endl;
 	cout << "  --strict-float: do not allow assignments between floats and integers" << endl << endl;
+
+    // type size options
+    cout << "  --int-size <size>: specify integer size of target (default taken from platform.info if it exists otherwise from host)"  << endl << endl;
+    cout << "  --ptr-size <size>: specify pointer size of target (default taken from platform.info if it exists otherwise from host)"  << endl << endl;
 }
 
 void arg_check(int argc, int i)
@@ -1474,6 +1478,26 @@ main(int argc, char **argv)
 			CGOptions::cpp11(true);
 			continue;
 		}
+
+        if (strcmp (argv[i], "--int-size") == 0) {
+			unsigned long size;
+			i++;
+			arg_check(argc, i);
+			if (!parse_int_arg(argv[i], &size))
+				exit(-1);
+            CGOptions::int_size(size);
+            continue;
+        }
+
+        if (strcmp (argv[i], "--ptr-size") == 0) {
+			unsigned long size;
+			i++;
+			arg_check(argc, i);
+			if (!parse_int_arg(argv[i], &size))
+				exit(-1);
+            CGOptions::pointer_size(size);
+            continue;
+        }
 
     if (strcmp(argv[i], "--fast-execution") == 0) {
       CGOptions::lang_cpp(true);


### PR DESCRIPTION
The use of a file for platform info can cause a problem when csmith is used concurrently with different platform options. To avoid this problem the command line switches `--int-size` and `--ptr-size`has been introduced and the creation of `platform.info` has been removed. For partial backwards compatibility the file is still read if it is present and the values inside are used as default values. Values specified on the command line have precedens over values in the `platform.info` file.