### PR TITLE
Change seed to actual number string in gen100.py

### DIFF
--- a/gen100.py
+++ b/gen100.py
@@ -1,6 +1,5 @@
 import os
 
 for seed in range(100):
-    print("Generating with seed", seed) 
-    os.system("src/csmith -s seed > " + str(seed)+ ".c")
-
+    print("Generating with seed", seed)
+    os.system("src/csmith -s" + str(seed) + " > " + str(seed) + ".c")


### PR DESCRIPTION
Previously was using "seed" as the input for seed, which is invalid since a number is expected. Now uses the intended seed number from the for loop.