### PR TITLE
Add option to remove static from globals

### DIFF
--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -334,6 +334,7 @@ static void print_advanced_help()
 
 	cout << "  --mark-mutable-const: mark constants that can be mutated with parentheses (disabled by default)." << endl << endl;
 
+	cout << "  --force-globals-static | --no-force-globals-static: force functions and global variables to use static storage (enabled by default)." << endl << endl;
 	cout << "  --force-non-uniform-arrays | --no-force-non-uniform-arrays: force integer arrays to be initialized with multiple values (enabled by default)." << endl << endl;
 
 	cout << "  --null-ptr-deref-prob <N>: allow null pointers to be dereferenced with probability N% (0 by default)." << endl << endl;
@@ -1243,6 +1244,11 @@ main(int argc, char **argv)
 
 		if (strcmp (argv[i], "--force-globals-static") == 0) {
 			CGOptions::force_globals_static(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-force-globals-static") == 0) {
+			CGOptions::force_globals_static(false);
 			continue;
 		}
 


### PR DESCRIPTION
For various experiments, it's useful to investigate how compilers treat each function separately, but Csmith defaults to marking all functions `static` which inhibits this.

As it happens, there is a long-lived setting within Csmith to decide whether globals should be forced as static, but it's currently always enabled with no CLI option to disable it.

This adds an advanced option to disable forced globals and documents the option in the help text.