### PR TITLE
support read_time() on aarch64 platform

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -92,7 +92,7 @@ static long long read_time(void)
 	return l;
 }
 #elif defined(__aarch64__)
-unsigned long long read_time()
+unsigned long read_time()
 {
 	unsigned long long val;
 	asm volatile ("mrs %0, cntvct_el0" : "=r" (val));

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -91,6 +91,13 @@ static long long read_time(void)
 				 );
 	return l;
 }
+#elif defined(__aarch64__)
+unsigned long long read_time()
+{
+	unsigned long long val;
+	asm volatile ("mrs %0, cntvct_el0" : "=r" (val));
+	return (unsigned long)(val&0x00000000FFFFFFFFLL);
+}
 #  else
 #    include <time.h>
 static long long read_time(void)


### PR DESCRIPTION
The Seed value after patch apply:

![image](https://github.com/csmith-project/csmith/assets/24123821/494247a0-1955-489a-adec-dc93f27b6d58)
