### PR TITLE
fix bugs: const MAX_FILTER_KIND_SIZE outside the valid range

### DIFF
--- a/src/Filter.h
+++ b/src/Filter.h
@@ -35,9 +35,8 @@
 enum FilterKind {
 	fDefault,
 	fDFS,
+	MAX_FILTER_KIND_SIZE
 };
-
-#define MAX_FILTER_KIND_SIZE ((FilterKind) (fDFS + 1))
 
 // Filter base class
 class Filter

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -92,7 +92,7 @@ static long long read_time(void)
 	return l;
 }
 #elif defined(__aarch64__)
-unsigned long long read_time()
+unsigned long read_time()
 {
 	unsigned long long val;
 	asm volatile ("mrs %0, cntvct_el0" : "=r" (val));

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -91,6 +91,13 @@ static long long read_time(void)
 				 );
 	return l;
 }
+#elif defined(__aarch64__)
+unsigned long long read_time()
+{
+	unsigned long long val;
+	asm volatile ("mrs %0, cntvct_el0" : "=r" (val));
+	return (unsigned long)(val&0x00000000FFFFFFFFLL);
+}
 #  else
 #    include <time.h>
 static long long read_time(void)


### PR DESCRIPTION
fix bugs: src/Filter.h:60:14: error: integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'FilterKind' [-Wenum-constexpr-conversion]; https://github.com/csmith-project/csmith/issues/163

Fixes: #163