### PR TITLE
fix bugs: const MAX_FILTER_KIND_SIZE outside the valid range

### DIFF
--- a/src/Filter.h
+++ b/src/Filter.h
@@ -35,9 +35,8 @@
 enum FilterKind {
 	fDefault,
 	fDFS,
+	MAX_FILTER_KIND_SIZE,
 };
-
-#define MAX_FILTER_KIND_SIZE ((FilterKind) (fDFS + 1))
 
 // Filter base class
 class Filter


### PR DESCRIPTION
fix bugs: src/Filter.h:60:14: error: integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'FilterKind' [-Wenum-constexpr-conversion]; https://github.com/csmith-project/csmith/issues/163

Fixes: #163